### PR TITLE
use v0.3.2-beta of imSim; use twilight fix in sims_skybrightness

### DIFF
--- a/Singularity
+++ b/Singularity
@@ -9,19 +9,26 @@ From: lsstdesc/stack-sims:w_2018_26-sims_2_9_0
    setup lsst_sims
    mkdir /DC2
    cd /DC2
+   git clone https://github.com/lsst/sims_skybrightness.git
    git clone https://github.com/lsst/sims_GalSimInterface.git
    git clone https://github.com/LSSTDESC/imSim.git
    git clone https://github.com/lsst/obs_lsstCam.git
+   setup -r sims_skybrightness -j
    setup -r sims_GalSimInterface -j
    setup -r imSim -j
    setup -r obs_lsstCam -j
+   cd sims_skybrightness
+   git checkout fdd58c7eb0414e89f5c7fa12eccf8809acabcf92
+   set +e
+   scons
+   set -e
    cd sims_GalSimInterface
    git checkout u/jchiang/uniqueId_as_string
    set +e
    scons
    set -e
    cd ../imSim
-   git checkout v0.3.1-beta
+   git checkout v0.3.2-beta
    scons
    cd ../obs_lsstCam
    git checkout imsim-0.1.0


### PR DESCRIPTION
This PR sets the imSim version to v0.3.2-beta which has the optical PSF fix and some better instance catalog object handling.

It also includes the twilight fix that Peter Yoachim implemented in `lsst/sims_skybrightness` (see [this #desc-dc2-eyeballs comment](https://lsstc.slack.com/archives/C932BQ550/p1536076592000100) and subsequent discussion.