### PR TITLE
Tighter (and Less Arbitrary) Bundling

### DIFF
--- a/scripts/example_bundle_run.py
+++ b/scripts/example_bundle_run.py
@@ -34,14 +34,14 @@ ict.determine_instcat_work(instcat_list_a, '/mnt/scripts/instcat_worklist_a.json
 with open('/mnt/scripts/instcat_worklist_a.json') as fp:
     worklist_a = json.load(fp)
 
-# We need to define the max number of threads and max number of instances per node for this. We choose
-# the fiducial values from Theta. Note that the max_instances_node is a non-trivial calculation.
-# We assume 10 GB memory per imSim call + 1 GB per thread + 5 GB floating for sharp increases.
-# This may vary depending on your version of imSim and architecture.
+# we now define key characteristics of the imSim version + architecture.
+mem_per_thread = 2      # the amount of memory a given sensor thread is expected to max out at
+mem_per_instance = 10   # the amount of shared memory an imSim container is expected to have
 
-max_threads_node = 64
-max_instances_node = 10
-bundle_list_a = jbu.determine_bundles(worklist_a, max_threads_node, max_instances_node)
+mem_per_node = 96-5     # the available memory on a compute node to target for use, minus some leeway
+threads_per_node = 68*4 # the number of available threads to be used on a given node
+
+bundle_list_a = jbu.determine_bundles(worklist_a, mem_per_thread, mem_per_instance, mem_per_node, threads_per_node)
 
 # This bundle list can be saved and used for your workflow of choice!
 with open('/mnt/scripts/bundle_worklist_a.json', 'w') as fp:
@@ -71,7 +71,7 @@ with open('/mnt/scripts/bundle_worklist_b.json', 'w') as fp:
 
 # And now let's combine THIS with our restart data to generate a new master bundling.
 worklist_new = jbu.determine_remaining_jobs('/mnt/scripts/bundle_worklist_b.json', restartpath)
-bundle_list_new = jbu.determine_bundles(worklist_new, max_threads_node, max_instances_node)
+bundle_list_new = jbu.determine_bundles(worklist_new, mem_per_thread, mem_per_instance, mem_per_node, threads_per_node)
 
 # And we can just save this new work list!
 with open('/mnt/scripts/bundle_worklist_new.json', 'w') as fp:

--- a/scripts/job_bundling_utils.py
+++ b/scripts/job_bundling_utils.py
@@ -1,4 +1,5 @@
 import numpy as np
+import math
 import json
 import sys
 import glob
@@ -23,12 +24,8 @@ def determine_bundles(sample, mem_per_thread=2, mem_per_instance=10, max_mem_nod
     # what the actual max threads are. If this is SMALLER than input max_threads,
     # this is corrected.
     mem=max_mem_node-mem_per_instance
-    thread_counter = 0
-    while mem > 0:
-        mem = mem - mem_per_thread
-        thread_counter+=1
-    if thread_counter < max_threads_node:
-        max_threads_node = thread_counter
+    tmp = math.floor(mem / mem_per_thread)
+    max_threads_node = min(tmp, max_threads_node)
 
     bundle_list = dict()
     bin_counter = 0

--- a/scripts/job_bundling_utils.py
+++ b/scripts/job_bundling_utils.py
@@ -24,7 +24,7 @@ def determine_bundles(sample, mem_per_thread=2, mem_per_instance=10, max_mem_nod
     # what the actual max threads are. If this is SMALLER than input max_threads,
     # this is corrected.
     mem=max_mem_node-mem_per_instance
-    tmp = math.floor(mem / mem_per_thread)
+    tmp = int(math.floor(mem / mem_per_thread))
     max_threads_node = min(tmp, max_threads_node)
 
     bundle_list = dict()

--- a/scripts/job_bundling_utils.py
+++ b/scripts/job_bundling_utils.py
@@ -61,28 +61,28 @@ def determine_bundles(sample, mem_per_thread=2, mem_per_instance=10, max_mem_nod
             # loop over existing bins to find a complete fit.
             for j in range(0, len(open_bins)):
                 if found_fit == 0:
-					# first define two tests: the threadcount test and the memcount test
-					threadcount = open_bins[j]+thread_counts[idx]
-					instancecount = num_fit[j]+1
-					threadcount_test = threadcount <= max_threads_node
-					memcount = mem_per_thread*threadcount + mem_per_instance*instancecount
-					memcount_test = memcount <= max_mem_node                    
-					# if an open bin is availaible to fit all threads, try to fit all the threads
+                    # first define two tests: the threadcount test and the memcount test
+                    threadcount = open_bins[j]+thread_counts[idx]
+                    instancecount = num_fit[j]+1
+                    threadcount_test = threadcount <= max_threads_node
+                    memcount = mem_per_thread*threadcount + mem_per_instance*instancecount
+                    memcount_test = memcount <= max_mem_node                    
+                    # if an open bin is availaible to fit all threads, try to fit all the threads
                     if threadcount_test == True and memcount_test == True: 
-                       open_bins[j]+=thread_counts[idx]
-                       num_fit[j]+=1
-                       temp_sensor = []
-                       temp_num = []
-                       for tempi in range(thread_counts[idx]):
-                           temp_sensor.append((sample[idx])[1].pop()
-                           temp_num.append((sample[idx])[2].pop())
-                       nodedict = 'node'+str(j+bin_adjust)
-                       bundle_list[nodedict].append(((sample[idx])[0], temp_sensor, temp_num))
-                       found_fit = 1
+                        open_bins[j]+=thread_counts[idx]
+                        num_fit[j]+=1
+                        temp_sensor = []
+                        temp_num = []
+                        for tempi in range(thread_counts[idx]):
+                            temp_sensor.append((sample[idx])[1].pop())
+                            temp_num.append((sample[idx])[2].pop())
+                        nodedict = 'node'+str(j+bin_adjust)
+                        bundle_list[nodedict].append(((sample[idx])[0], temp_sensor, temp_num))
+                        found_fit = 1
 			# if this is in a small-ish box, odds are we can slice things up a little to fit.
             if found_fit == 0 and thread_counts[idx] < max_threads_node/2:
                 for j in range(0, len(open_bins)):
-				    # this time, for each j we want to do the same thing, but now we will allow a
+                    # this time, for each j we want to do the same thing, but now we will allow a
                     # variable SLICE to be added. Calculate instance memory the same...
                     instancecount = num_fit[j]+1
                     memremaining = max_mem_node - mem_per_thread*open_bins[j] - mem_per_instance*instancecount
@@ -92,7 +92,7 @@ def determine_bundles(sample, mem_per_thread=2, mem_per_instance=10, max_mem_nod
                         memremaining = memremaining - mem_per_thread
                         sliceint += 1
                     threadcount = open_bins[j]+sliceint
-                    memcount = mem_per_thread*threadconut + mem_per_instance*instancecount
+                    memcount = mem_per_thread*threadcount + mem_per_instance*instancecount
                     memcount_test = memcount <= max_mem_node
                     threadcount_test = threadcount <= max_threads_node
                     if found_fit == 0 and thread_counts[idx] > sliceint:

--- a/scripts/parsl-bundle.py
+++ b/scripts/parsl-bundle.py
@@ -23,16 +23,15 @@ restartpath = sys.argv[5]
 with open(worklist) as fp:
     worklist_a = json.load(fp)
 
-# We need to define the max number of threads and max number of instances per node for this. We choose
-# the fiducial values from Theta. Note that the max_instances_node is a non-trivial calculation.
-# We assume 10 GB memory per imSim call + 1 GB per thread + 5 GB floating for sharp increases.
-# This may vary depending on your version of imSim and architecture.
+# we now define key characteristics of the imSim version + architecture.
+mem_per_thread = 2      # the amount of memory a given sensor thread is expected to max out at
+mem_per_instance = 10   # the amount of shared memory an imSim container is expected to have
 
-max_threads_node = 32
-max_instances_node = 1
+mem_per_node = 96-5     # the available memory on a compute node to target for use, minus some leeway
+threads_per_node = 68*4 # the number of available threads to be used on a given node
 
 print("parsl-initial-bundle: Bundling first pass...")
-bundle_list_a = jbu.determine_bundles(worklist_a, max_threads_node, max_instances_node)
+bundle_list_a = jbu.determine_bundles(worklist_a, mem_per_thread, mem_per_instance, mem_per_node, threads_per_node)
 
 # This bundle list can be saved and used for your workflow of choice!
 with open(bundles, 'w') as fp:
@@ -47,7 +46,7 @@ worklist_new = jbu.determine_remaining_jobs("/projects/LSSTADSP_DESC/Run2.0i-par
 
 print("parsl-initial-bundle: Bundling second pass...")
 
-bundle_list_new = jbu.determine_bundles(worklist_new, max_threads_node, max_instances_node)
+bundle_list_new = jbu.determine_bundles(worklist_new, mem_per_thread, mem_per_instance, mem_per_node, threads_per_node)
 
 with open(bundles, 'w') as fp:
     json.dump(bundle_list_new, fp)


### PR DESCRIPTION
This version of the code dramatically changes the bundling algorithm in order to change from using fairly arbitrary choices of "number of instances per node" and "number of threads per node" to instead use the combination of imSim performance and machine requirements. Specifically:

mem_per_thread = the amount of memory an imSim thread maxes out on.
mem_per_instance = the amount of shared memory an imSim instance takes.
mem_per_node = the total amount of memory available on a node WITH SOME BUFFER SUBTRACTED.
threads_per_node = the total amount of hardware threads available for processing jobs.

With this set-up in place, we now dynamically determine the remaining memory and allowed threads on each bundle so as to pack work more optimally. Note, this does not account for any sort of multiprocessing driven refilling, which would require a considerably different architecture to this bundler (and likely would be a simpler case of each node gets one visit with all the sensors on it).